### PR TITLE
EXPLORE-22: Updates to Infra Up and Down

### DIFF
--- a/.github/workflows/infra-down.yaml
+++ b/.github/workflows/infra-down.yaml
@@ -1,0 +1,57 @@
+name: Infrastructure Down
+
+on:
+    workflow_dispatch:
+    workflow_call:
+
+env:
+    AWS_REGION: ap-southeast-1
+    TF_VERSION: 1.5.0
+
+jobs:
+    terraform-destroy:
+        name: Tear Down EKS Infrastructure
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ${{ env.AWS_REGION }}
+
+            - name: Setup Terraform
+              uses: hashicorp/setup-terraform@v3
+              with:
+                  terraform_version: ${{ env.TF_VERSION }}
+
+            - name: Terraform Init
+              working-directory: ./infra/environments/prod
+              run: terraform init
+
+            - name: Remove Helm Releases (if any)
+              continue-on-error: true
+              run: |
+                  aws eks update-kubeconfig \
+                    --name exploresg-prod-cluster \
+                    --region ${{ env.AWS_REGION }} || true
+
+                  helm uninstall aws-load-balancer-controller -n kube-system || true
+
+            - name: Terraform Destroy - EKS Only
+              working-directory: ./infra/environments/prod
+              run: |
+                  terraform destroy -auto-approve \
+                    -target=module.eks \
+                    -target=module.vpc.aws_nat_gateway.main
+
+            - name: Infrastructure Destroyed
+              run: |
+                  echo "✅ EKS Cluster destroyed"
+                  echo "✅ NAT Gateways removed"
+                  echo "💰 Hourly costs stopped"
+                  echo "📝 VPC remains for next deployment"

--- a/.github/workflows/infra-up.yaml
+++ b/.github/workflows/infra-up.yaml
@@ -54,20 +54,20 @@ jobs:
                   terraform_version: ${{ env.TF_VERSION }}
 
             - name: 🔄 Terraform Init
-              working-directory: ./infra
+              working-directory: ./infra/environments/prod
               run: terraform init
 
             - name: 📋 Terraform Plan
-              working-directory: ./infra
+              working-directory: ./infra/environments/prod
               run: |
                   echo "📊 Planning infrastructure changes..."
                   terraform plan \
                     -target=module.eks \
-                    -target=aws_nat_gateway.main \
+                    -target=module.vpc.aws_nat_gateway.main \
                     -out=tfplan
 
             - name: 🚀 Terraform Apply
-              working-directory: ./infra
+              working-directory: ./infra/environments/prod
               run: |
                   echo "🏗️ Provisioning EKS cluster and NAT gateways..."
                   terraform apply -auto-approve tfplan


### PR DESCRIPTION
This pull request introduces a new workflow for tearing down EKS infrastructure and updates the existing infrastructure provisioning workflow to improve consistency and accuracy. The main focus is on automating and streamlining the management of AWS resources using GitHub Actions and Terraform.

**New infrastructure teardown workflow:**

* Added a new `.github/workflows/infra-down.yaml` workflow that automates the destruction of EKS and NAT gateway resources using Terraform, including steps for AWS authentication, Helm release cleanup, and user feedback on resource removal.

**Improvements to infrastructure provisioning:**

* Updated the `.github/workflows/infra-up.yaml` workflow to use the correct working directory (`./infra/environments/prod`) for all Terraform commands, ensuring consistency with the teardown workflow and correct state management.
* Corrected the Terraform plan target for NAT gateways from `aws_nat_gateway.main` to `module.vpc.aws_nat_gateway.main` to match the module structure and ensure the correct resources are managed.